### PR TITLE
release-checklist: can't pyflakes handlers/ - those are now inside dexy/f

### DIFF
--- a/release-checklist.sh
+++ b/release-checklist.sh
@@ -1,6 +1,5 @@
 echo "running pyflakes"
 pyflakes dexy/
-pyflakes handlers/
 
 echo "Checking if all changes have been committed to git and pushed..."
 


### PR DESCRIPTION
release-checklist: can't pyflakes handlers/ - those are now inside dexy/filters/
