### PR TITLE
Make the argument to md5 a string.

### DIFF
--- a/dexy/artifact.py
+++ b/dexy/artifact.py
@@ -373,7 +373,7 @@ class Artifact(object):
                     hash_v = OrderedDict()
                     for k1 in sorted(v.keys()):
                         v1 = v[k1]
-                        hash_v[str(k1)] = hashlib.md5(v1).hexdigest()
+                        hash_v[str(k1)] = hashlib.md5(str(v1)).hexdigest()
                 else:
                     hash_v = str(v)
                 hash_dict[str(k)] = hash_v


### PR DESCRIPTION
Fixes this test error:
## ERROR: dexy.tests.test_artifact.test_add_additional_artifact

Traceback (most recent call last):
  File "/usr/local/lib/python2.6/dist-packages/nose-0.11.1-py2.6.egg/nose/case.py", line 183, in runTest
    self.test(*self.arg)
  File "/home/rpavlik/src/third-party/dexy/dexy/tests/test_artifact.py", line 48, in test_add_additional_artifact
    new_artifact = artifact.add_additional_artifact('def.txt', '.txt')
  File "/home/rpavlik/src/third-party/dexy/dexy/artifact.py", line 329, in add_additional_artifact
    new_artifact.set_hashstring()
  File "/home/rpavlik/src/third-party/dexy/dexy/artifact.py", line 384, in set_hashstring
    hash_data = str(self.hash_dict())
  File "/home/rpavlik/src/third-party/dexy/dexy/artifact.py", line 376, in hash_dict
    hash_v[str(k1)] = hashlib.md5(v1).hexdigest()
TypeError: md5() argument 1 must be string or read-only buffer, not dict

and a similar error ("not bool") when trying to build Learn X The Hard Way.
