### PR TITLE
Asciidoc extensions include '.asciidoc', '.ad' and '.adoc'

### DIFF
--- a/dexy/filters/subprocess_filters.py
+++ b/dexy/filters/subprocess_filters.py
@@ -62,7 +62,7 @@ class EspeakFilter(SubprocessFilter):
 class AsciidocFilter(SubprocessFilter):
     VERSION_COMMAND = "asciidoc --version"
     EXECUTABLE = "asciidoc"
-    INPUT_EXTENSIONS = [".txt"]
+    INPUT_EXTENSIONS = [".asciidoc", ".ad", ".adoc", ".txt"]
     OUTPUT_EXTENSIONS = [".html", ".xml"]
     ALIASES = ['asciidoc']
     BINARY = False


### PR DESCRIPTION
The O'Reilly toolchain in particular demands `.asciidoc`. Yes I know the site says the official extension is `.txt`. Nice attempt at global dominance, but nobody uses .txt for asciidoc documents.
