### PR TITLE
pycon filter lacked 'INITIAL_PROMPT' setting, causing crash on OSX

### DIFF
--- a/dexy/filters/pexpect_filters.py
+++ b/dexy/filters/pexpect_filters.py
@@ -129,9 +129,9 @@ class PexpectReplFilter(ProcessFilter):
 
         # Spawn the process
         proc = pexpect.spawn(
-                self.executable(),
-                cwd=cwd,
-                env=env)
+            self.executable(),
+            cwd=cwd,
+            env=env)
 
         self.log.debug("Capturing initial prompt...")
         try:
@@ -276,6 +276,7 @@ class PythonPexpectReplFilter(PexpectReplFilter):
     OUTPUT_LEXER = "pycon"
     TAGS = ['python', 'interpreter', 'language']
     VERSION_COMMAND = 'python --version'
+    INITIAL_PROMPT = ">>>"
 
     SAVE_VARS_TO_JSON_CMD = """
 import json


### PR DESCRIPTION
can't run pycon filter on OSX. attached patch fixes by setting an INITIAL_PROMPT

what it looks like when I start python:

```
worblehat ~/ics/ext/dexy$ python
Python 2.7.3 (default, May 13 2012, 11:41:02) 
[GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.15.00)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> note_the_space_between('>>>', 'and rest of line')
```

the error:

```
worblehat ~/ics/ext/dexy/test-examples$ dexy -danger --loglevel DEBUG
batch id is 9
sorting 16 documents into run order, there are 2 total dependencies
ratio of dependencies to documents is 0.1
ERROR in test-idio.py|idio|pycon|pyg|l (in filter 'pycon' - step 2 of 4)
Traceback (most recent call last):
  File "/usr/local/bin/dexy", line 8, in <module>
    load_entry_point('dexy==0.6.0', 'console_scripts', 'dexy')()
  File "/Users/flip/ics/ext/dexy/dexy/commands.py", line 55, in run
    args.parse_and_run_command(sys.argv[1:], MOD, default_command=Constants.DEFAULT_COMMAND)
  File "/Library/Python/2.7/site-packages/modargs/args.py", line 375, in parse_and_run_command
    command_module(mod, command, options)
  File "/Library/Python/2.7/site-packages/modargs/args.py", line 283, in command_module
    function(**options)
  File "/Users/flip/ics/ext/dexy/dexy/commands.py", line 150, in dexy_command
    controller = run_dexy(locals())
  File "/Users/flip/ics/ext/dexy/dexy/commands.py", line 175, in run_dexy
    controller.run()
  File "/Users/flip/ics/ext/dexy/dexy/controller.py", line 87, in run
    self.docs = [doc.run() for doc in self.docs]
  File "/Users/flip/ics/ext/dexy/dexy/document.py", line 376, in run
    artifact.run()
  File "/Users/flip/ics/ext/dexy/dexy/artifact.py", line 426, in run
    raise e
dexy.commands.InternalDexyProblem: 
Oops! You may have found a bug in Dexy.
        The developer would really appreciate if you copy and paste this entire message
        and the Traceback above it into a bug report at http://dexy.tenderapp.com.
        Your version of Dexy is 0.6.0
        Your platform is Darwin
PythonPexpectReplFilter failed at matching initial prompt within 8 seconds. Received 'Python 2.7.3 (default, May 13 2012, 11:41:02) 
[GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.15.00)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> ', tried to match with '['\n>>>', '\n...']'
Exact characters received:
chr 00: 80
chr 01: 121
chr 02: 116
chr 03: 104
chr 04: 111
chr 05: 110
chr 06: 32
chr 07: 50
chr 08: 46
chr 09: 55
chr 10: 46
chr 11: 51
chr 12: 32
chr 13: 40
chr 14: 100
chr 15: 101
chr 16: 102
chr 17: 97
chr 18: 117
chr 19: 108
chr 20: 116
chr 21: 44
chr 22: 32
chr 23: 77
chr 24: 97
chr 25: 121
chr 26: 32
chr 27: 49
chr 28: 51
chr 29: 32
chr 30: 50
chr 31: 48
chr 32: 49
chr 33: 50
chr 34: 44
chr 35: 32
chr 36: 49
chr 37: 49
chr 38: 58
chr 39: 52
chr 40: 49
chr 41: 58
chr 42: 48
chr 43: 50
chr 44: 41
chr 45: 32
chr 46: 13
chr 47: 10
chr 48: 91
chr 49: 71
chr 50: 67
chr 51: 67
chr 52: 32
chr 53: 52
chr 54: 46
chr 55: 50
chr 56: 46
chr 57: 49
chr 58: 32
chr 59: 40
chr 60: 66
chr 61: 97
chr 62: 115
chr 63: 101
chr 64: 100
chr 65: 32
chr 66: 111
chr 67: 110
chr 68: 32
chr 69: 65
chr 70: 112
chr 71: 112
chr 72: 108
chr 73: 101
chr 74: 32
chr 75: 73
chr 76: 110
chr 77: 99
chr 78: 46
chr 79: 32
chr 80: 98
chr 81: 117
chr 82: 105
chr 83: 108
chr 84: 100
chr 85: 32
chr 86: 53
chr 87: 54
chr 88: 53
chr 89: 56
chr 90: 41
chr 91: 32
chr 92: 40
chr 93: 76
chr 94: 76
chr 95: 86
chr 96: 77
chr 97: 32
chr 98: 98
chr 99: 117
chr 100: 105
chr 101: 108
chr 102: 100
chr 103: 32
chr 104: 50
chr 105: 51
chr 106: 51
chr 107: 53
chr 108: 46
chr 109: 49
chr 110: 53
chr 111: 46
chr 112: 48
chr 113: 48
chr 114: 41
chr 115: 93
chr 116: 32
chr 117: 111
chr 118: 110
chr 119: 32
chr 120: 100
chr 121: 97
chr 122: 114
chr 123: 119
chr 124: 105
chr 125: 110
chr 126: 13
chr 127: 10
chr 128: 84
chr 129: 121
chr 130: 112
chr 131: 101
chr 132: 32
chr 133: 34
chr 134: 104
chr 135: 101
chr 136: 108
chr 137: 112
chr 138: 34
chr 139: 44
chr 140: 32
chr 141: 34
chr 142: 99
chr 143: 111
chr 144: 112
chr 145: 121
chr 146: 114
chr 147: 105
chr 148: 103
chr 149: 104
chr 150: 116
chr 151: 34
chr 152: 44
chr 153: 32
chr 154: 34
chr 155: 99
chr 156: 114
chr 157: 101
chr 158: 100
chr 159: 105
chr 160: 116
chr 161: 115
chr 162: 34
chr 163: 32
chr 164: 111
chr 165: 114
chr 166: 32
chr 167: 34
chr 168: 108
chr 169: 105
chr 170: 99
chr 171: 101
chr 172: 110
chr 173: 115
chr 174: 101
chr 175: 34
chr 176: 32
chr 177: 102
chr 178: 111
chr 179: 114
chr 180: 32
chr 181: 109
chr 182: 111
chr 183: 114
chr 184: 101
chr 185: 32
chr 186: 105
chr 187: 110
chr 188: 102
chr 189: 111
chr 190: 114
chr 191: 109
chr 192: 97
chr 193: 116
chr 194: 105
chr 195: 111
chr 196: 110
chr 197: 46
chr 198: 13
chr 199: 10
chr 200: 27
chr 201: 91
chr 202: 63
chr 203: 49
chr 204: 48
chr 205: 51
chr 206: 52
chr 207: 104
chr 208: 62
chr 209: 62
chr 210: 62
chr 211: 32
The developer might need to set a longer INITIAL_PROMPT_TIMEOUT or the regexp may be wrong.
```
