### PR TITLE
filter-not-found warning reports the executables it tried (not "None")

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ logs/
 !dexy/artifacts/
 build
 dist
+test-examples/output
+test-examples/output-long
+examples/*/output
+examples/*/output-long

--- a/dexy/introspect.py
+++ b/dexy/introspect.py
@@ -161,7 +161,7 @@ def filters(log=NULL_LOGGER):
                                 log.info("class %s is not available because it has no aliases" % klass.__name__)
                             elif len(klass.executables()) > 0 and not klass.executable():
                                 log.info("class %s is not available because %s not found" %
-                                              (klass.__name__, klass.executable()))
+                                              (klass.__name__, klass.executables()))
                             elif not klass.enabled():
                                 log.info("class %s is not available because it is not enabled" %
                                               (klass.__name__))


### PR DESCRIPTION
Since the exeutable is tatutologically not found, the filter-not-found warning alwasy says 'None': `class CasperJsStdoutFilter is not available because None not found`.

This changes it to call `executables` not `executable`: `class CasperJsSvg2PdfFilter is not available because [casperjs] not found`
