### PR TITLE
OrderedDict is in collections module in python-2.7+

### DIFF
--- a/dexy/artifact.py
+++ b/dexy/artifact.py
@@ -1,5 +1,5 @@
 from dexy.task import Task
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 import dexy.data
 import dexy.doc
 import dexy.exceptions

--- a/dexy/common.py
+++ b/dexy/common.py
@@ -1,0 +1,4 @@
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict

--- a/dexy/metadata.py
+++ b/dexy/metadata.py
@@ -1,5 +1,5 @@
 from dexy.plugin import PluginMeta
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 import hashlib
 import sqlite3
 

--- a/dexy/plugins/example_filters.py
+++ b/dexy/plugins/example_filters.py
@@ -3,7 +3,7 @@ Filters written to be examples of how to write filters.
 """
 from dexy.doc import Doc
 from dexy.filter import Filter
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 
 class KeyValueExample(Filter):
     ALIASES = ['keyvalueexample']

--- a/dexy/plugins/idio_filters.py
+++ b/dexy/plugins/idio_filters.py
@@ -1,6 +1,6 @@
 from dexy.plugins.pygments_filters import PygmentsFilter
 from idiopidae.runtime import Composer
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 import idiopidae.parser
 import re
 

--- a/dexy/plugins/pygments_filters.py
+++ b/dexy/plugins/pygments_filters.py
@@ -1,5 +1,5 @@
 from dexy.filter import Filter
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.formatters import LatexFormatter

--- a/dexy/plugins/split_filters.py
+++ b/dexy/plugins/split_filters.py
@@ -1,7 +1,7 @@
 from dexy.filter import Filter
 import re
 import os
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 
 class SplitHtmlFilter(Filter):
     """

--- a/dexy/plugins/standard_filters.py
+++ b/dexy/plugins/standard_filters.py
@@ -1,7 +1,7 @@
 from dexy.filter import Filter
 import json
 import copy
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 
 class MarkupTagsFilter(Filter):
     """

--- a/dexy/plugins/templating_plugins.py
+++ b/dexy/plugins/templating_plugins.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from dexy.artifact import Artifact
 from dexy.doc import Doc, PatternDoc
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 from pygments.styles import get_all_styles
 import calendar
 import dexy.artifact

--- a/dexy/storage.py
+++ b/dexy/storage.py
@@ -1,6 +1,6 @@
 from dexy.plugin import PluginMeta
 import shutil
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 import os
 
 # Generic Data

--- a/dexy/tests/plugins/test_standard_filters.py
+++ b/dexy/tests/plugins/test_standard_filters.py
@@ -1,7 +1,7 @@
 from dexy.tests.utils import assert_output
 from dexy.tests.utils import temprun
 from dexy.doc import Doc
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 
 def test_join_filter():
     contents = OrderedDict()

--- a/dexy/tests/test_data.py
+++ b/dexy/tests/test_data.py
@@ -1,2 +1,2 @@
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 from dexy.runner import Runner

--- a/dexy/tests/test_doc.py
+++ b/dexy/tests/test_doc.py
@@ -1,6 +1,6 @@
 from dexy.doc import Doc
 from dexy.doc import PatternDoc
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 from dexy.exceptions import *
 from dexy.filter import DexyFilter
 from dexy.data import Data

--- a/dexy/tests/test_runner.py
+++ b/dexy/tests/test_runner.py
@@ -2,7 +2,7 @@ from dexy.doc import Doc
 from dexy.params import RunParams
 from dexy.runner import Runner
 from dexy.tests.utils import tempdir
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 import os
 
 def test_runner_init():

--- a/dexy/tests/utils.py
+++ b/dexy/tests/utils.py
@@ -7,7 +7,7 @@ from dexy.runner import Runner
 from dexy.utils import char_diff
 from modargs import args as modargs
 from nose.exc import SkipTest
-from ordereddict import OrderedDict
+from dexy.common import OrderedDict
 import dexy.commands
 import dexy.data
 import dexy.metadata


### PR DESCRIPTION
Try to first import OrderedDict from the collections module and then from ordereddict module as a fall back.

See: http://docs.python.org/library/collections.html
