### PR TITLE
Simple Node.js filter

### DIFF
--- a/dexy/plugins/__init__.py
+++ b/dexy/plugins/__init__.py
@@ -14,6 +14,7 @@ import dexy.plugins.output_reporters
 import dexy.plugins.parsers
 import dexy.plugins.pexpect_filters
 import dexy.plugins.phantomjs_filters
+import dexy.plugins.nodejs_filters
 import dexy.plugins.pydoc_filters
 import dexy.plugins.pygments_filters
 import dexy.plugins.pygments_plugins

--- a/dexy/plugins/nodejs_filters.py
+++ b/dexy/plugins/nodejs_filters.py
@@ -1,0 +1,15 @@
+from dexy.plugins.process_filters import SubprocessFilter
+from dexy.plugins.process_filters import SubprocessStdoutFilter
+import os
+
+class NodeJsStdoutFilter(SubprocessStdoutFilter):
+    """
+    Runs scripts using node js.
+    """
+    ADD_NEW_FILES = True
+    ALIASES = ['nodejs']
+    EXECUTABLE = 'node'
+    INPUT_EXTENSIONS = ['.js', '.txt']
+    OUTPUT_EXTENSIONS = ['.txt']
+    VERSION_COMMAND = 'node --version'
+


### PR DESCRIPTION
Hi, I just added a simple NodeJsStdoutFilter. It is more convenient than the PhantomJsStdoutFilter for 'pure' JavaScript files (i.e. non browser related).
Wondering if you would be interested in including it in the default filters.
