### PR TITLE
Support use of external template sources for website reporter

### DIFF
--- a/dexy/reporters/__init__.py
+++ b/dexy/reporters/__init__.py
@@ -2,3 +2,4 @@ import dexy.reporters.run
 import dexy.reporters.output
 import dexy.reporters.website
 import dexy.reporters.nodegraph
+import dexy.reporters.supplementary

--- a/dexy/reporters/supplementary/__init__.py
+++ b/dexy/reporters/supplementary/__init__.py
@@ -1,0 +1,1 @@
+from reporter import SupplementaryReporter

--- a/dexy/reporters/supplementary/reporter.py
+++ b/dexy/reporters/supplementary/reporter.py
@@ -27,7 +27,7 @@ class SupplementaryReporter(Website):
         return env
 
     def add_indigo_nodes(self):
-        # Create a new wrapper object which dexifies the indigo project folder
+        # Create a new wrapper object which dexifies the supplementary project folder
         # with cache objects etc being generated into the current cache, not a new one
         current_artifacts =  os.path.realpath(self.wrapper.artifacts_dir)
         with safe_cwd(self.setting('supplementary-location')):

--- a/dexy/reporters/supplementary/reporter.py
+++ b/dexy/reporters/supplementary/reporter.py
@@ -1,0 +1,44 @@
+from dexy.reporters.website import Website
+from jinja2 import FileSystemLoader
+from wrapper import SupplementaryWrapper
+from dexy.utils import safe_cwd
+import os
+
+class SupplementaryReporter(Website):
+    """
+    Acts like website reporter, but accepts additional template
+    materials from some other location, merging in the contents of the
+    .dexy file and other materials from that location.
+    Use to write a template only once which you intend to apply to
+    many websites
+    """
+    aliases = ['supplementary']
+    _settings = {
+        "supplementary-location" : ("Path to find supplementary files", os.path.dirname(__file__))
+    }
+    def setup(self):
+        super(SupplementaryReporter, self).setup()
+        self.add_indigo_nodes()
+
+    def jinja_environment(self, template_path, additional_args=None):
+        env = super(SupplementaryReporter, self).jinja_environment(template_path, additional_args)
+        dirs = [".", self.setting('supplementary-location'), os.path.dirname(template_path)]
+        env.loader = FileSystemLoader(dirs)
+        return env
+
+    def add_indigo_nodes(self):
+        # Create a new wrapper object which dexifies the indigo project folder
+        # with cache objects etc being generated into the current cache, not a new one
+        current_artifacts =  os.path.realpath(self.wrapper.artifacts_dir)
+        with safe_cwd(self.setting('supplementary-location')):
+           wrapper = SupplementaryWrapper()
+           wrapper.artifacts_dir = current_artifacts
+           wrapper.writeanywhere = True
+           wrapper.run_from_new()
+        # Copy the nodes and filemap from the new wrapper into the main wrapper
+        # so that they are picked up by the reporter.
+        self.wrapper.filemap.update(wrapper.filemap)
+        self.wrapper.nodes.update(wrapper.nodes)
+        for node in wrapper.nodes.values():
+            self.wrapper.batch.add_doc(node)
+

--- a/dexy/reporters/supplementary/wrapper.py
+++ b/dexy/reporters/supplementary/wrapper.py
@@ -1,0 +1,30 @@
+from dexy.wrapper import Wrapper
+import os
+
+class SupplementaryWrapper(Wrapper):
+    """
+    Wrapper which will add its files and work to an existing set of caches
+    rather than work from scratch
+    """
+    def check(self):
+        if not os.path.exists(self.this_cache_dir()):
+            self.create_cache_dir_with_sub_dirs(self.this_cache_dir())
+
+        # Load information about arguments from previous batch.
+        self.load_node_argstrings()
+
+        self.check_cache()
+
+        # Save information about this batch's arguments for next time.
+        self.save_node_argstrings()
+
+    def run(self):
+        if self.target:
+            matches = self.roots_matching_target()
+        else:
+            matches = self.roots
+
+        for node in matches:
+            for task in node:
+                task()
+

--- a/dexy/reporters/website/classes.py
+++ b/dexy/reporters/website/classes.py
@@ -224,6 +224,7 @@ class Website(Output):
             }))
 
         env_data = dict((k, v[1]) for k, v in raw_env_data.iteritems())
+        env_data["reporter_settings"]=self.settings_and_attributes()
 
         if doc.safe_setting('apply-ws-to-content'):
             env_data['content'] = self.apply_jinja_to_page_content(doc, env_data)

--- a/dexy/reporters/website/classes.py
+++ b/dexy/reporters/website/classes.py
@@ -64,7 +64,7 @@ class Website(Output):
     _settings = {
         "dir" : "output-site",
         "default-template" : ("Path to the default template to apply.", "_template.html"),
-        "root" : ("Path to which the webserver will be deployed. Dexy doesn't do anything with this, but it is available to your templates", '/'),
+        "root" : ("Path to which the webserver will be deployed. Dexy doesn't do anything with this, but it is available to your templates", ''),
         "default" : False
     }
 

--- a/dexy/reporters/website/classes.py
+++ b/dexy/reporters/website/classes.py
@@ -64,6 +64,7 @@ class Website(Output):
     _settings = {
         "dir" : "output-site",
         "default-template" : ("Path to the default template to apply.", "_template.html"),
+        "root" : ("Path to which the webserver will be deployed. Dexy doesn't do anything with this, but it is available to your templates", '/'),
         "default" : False
     }
 
@@ -225,6 +226,7 @@ class Website(Output):
 
         env_data = dict((k, v[1]) for k, v in raw_env_data.iteritems())
         env_data["reporter_settings"]=self.settings_and_attributes()
+        env_data["root"]=self.setting('root')
 
         if doc.safe_setting('apply-ws-to-content'):
             env_data['content'] = self.apply_jinja_to_page_content(doc, env_data)

--- a/dexy/utils.py
+++ b/dexy/utils.py
@@ -11,6 +11,7 @@ import shutil
 import tempfile
 import time
 import yaml
+import contextlib
 
 is_windows = platform.system() in ('Windows',)
 
@@ -327,6 +328,15 @@ def levenshtein(s1, s2):
         else:
           matrix[zz+1][sz+1] = min(matrix[zz+1][sz] + 1, matrix[zz][sz+1] + 1, matrix[zz][sz] + 1)
     return matrix[l2][l1]
+
+@contextlib.contextmanager
+def safe_cwd(path):
+    cwd=os.getcwd()
+    try:
+       os.chdir(path)
+       yield
+    finally:
+        os.chdir(cwd)
 
 def indent(s, spaces=4):
     return "\n".join("%s%s" % (' ' * spaces, line)


### PR DESCRIPTION
Hi @ananelson 

I wanted to be able to keep the website reporter template/scaffold files for our layout separately from the several dexy based repositories I have.

This commit would implement a "supplementary" reporter, with a path to a location with an additional dexy.yaml
The files from processing that folder are added to the current run, _at the reporter stage_, and templates are taken from that location.

I have not attempted to do the more complicated problem of merging two dexy.yaml files at the main run stage.

Let me know if you think this is useful/interesting.

Not ready for pull yet: I want to do as we discussed and set up some stuff for adding custom variables to the reporter which can be read by the templates, to tailor the templates.
