### PR TITLE
Fix for rst2beamer filter.

### DIFF
--- a/dexy/filters/filters.yaml
+++ b/dexy/filters/filters.yaml
@@ -1034,7 +1034,7 @@ rst2beamer:
     class: SubprocessFilter
     help: Runs rst2beamer command (docutils).
     tags: [reStructuredText]
-    executable: rst2beamer.py
+    executable: rst2beamer
     input-extensions: [".rst", ".txt"]
     output-extensions: [".tex"]
     version-command: "rst2beamer --version"


### PR DESCRIPTION
Fixing rst2beamer. rst2beamer executable doesn't end in .py, unlike the other rst2\* utilities.
