### PR TITLE
Properly handle code with non ASCII characters

### DIFF
--- a/dexy/filters/pyg.py
+++ b/dexy/filters/pyg.py
@@ -276,7 +276,18 @@ class PygmentsFilter(DexyFilter):
                 formatter = self.create_formatter_instance()
                 for section_name, section_input in self.input_data.iteritems():
                     try:
-                        section_output = highlight(unicode(section_input).decode("utf-8"), lexer, formatter)
+                        if isinstance(section_input, str):
+                            # If section_input is a 'str' instance we
+                            # assume it is encoded with UTF-8 and then we
+                            # convert it to a unicode string
+                            section_input = unicode(section_input, 'utf-8')
+                        else:
+                            # If section_input is an instance of
+                            # SectionValue then calling 'unicode' on this
+                            # instance will call the __unicode__ method of
+                            # SectionValue.
+                            section_input = unicode(section_input)
+                        section_output = highlight(section_input, lexer, formatter)
                     except UnicodeDecodeError:
                         if self.setting('allow-unprintable-input'):
                             section_input = self.setting('unprintable-input-text')


### PR DESCRIPTION
Without this change if a file which is processed with the pyg
filter (tested including only the pyg filter) has any non ASCII
character we will get the non printable text as if the file had binary
data.
